### PR TITLE
docs: document Antigravity CLI remote plugin install

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ You can install plugins directly from a remote GitHub repository.
 **1. Install the plugin:**
 
 ```bash
-agy plugins install https://github.com/gemini-cli-extensions/cloud-sql-sqlserver
+agy plugin install https://github.com/gemini-cli-extensions/cloud-sql-sqlserver
 ```
 
 **2. Set env vars:**

--- a/README.md
+++ b/README.md
@@ -127,28 +127,16 @@ _(Tip: Antigravity 2.0 automatically discovers skills in these directories at th
 
 #### Antigravity CLI
 
-**1. Clone the Repo:**
+You can install plugins directly from a remote GitHub repository.
+
+**1. Install the plugin:**
 
 ```bash
-git clone --branch 0.2.0 https://github.com/gemini-cli-extensions/cloud-sql-sqlserver.git
+agy plugins install https://github.com/gemini-cli-extensions/cloud-sql-sqlserver
 ```
 
-**2. Install the skills:**
-
-Choose a location for the skills:
-- **Global (all workspaces):** `~/.gemini/antigravity-cli/skills/`
-- **Workspace-specific:** `<workspace-root>/.agents/skills/`
-
-Copy the skill folders from the cloned repository's `skills/` directory to your chosen location:
-
-```bash
-cp -R cloud-sql-sqlserver/skills/* ~/.gemini/antigravity-cli/skills/
-```
-
-**3. Set env vars:**
+**2. Set env vars:**
 Set your environment vars as described in the [configuration section](#configuration).
-
-_(Tip: Antigravity CLI automatically discovers skills in these directories at the start of a session. You can verify they are active by running the `/skills` command in your active session.)_
 
 </details>
 


### PR DESCRIPTION
## Summary
- Replace the manual clone-and-copy Antigravity CLI install steps with the direct `agy plugins install <github-repo>` command
- Adapts the guidance from GoogleCloudPlatform/data-agent-kit#46 for this individual plugin repo

Replicates https://github.com/gemini-cli-extensions/cloud-sql-postgresql/pull/182